### PR TITLE
Interval revision policy test & validation

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,4 +1,3 @@
 node_modules
-test
 scripts
 coverage

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -91,8 +91,8 @@ function validateIndexSchema(schema, index) {
  * of the preconditions fail.
  *
  * The following preconditions are validated:
- * - Only keys 'type', 'grace_ttl' and 'count' are allowed
- * - Type can be 'all' and 'latest'
+ * - Only keys 'type', 'interval', 'grace_ttl' and 'count' are allowed
+ * - Type can be 'all', 'latest' and 'interval'
  *
  * @param schema original table schema
  */
@@ -105,8 +105,8 @@ function validateAndNormalizeRevPolicy(schema) {
             var val = policy[key];
             switch(key) {
                 case 'type':
-                    if (val !== 'all' && val !== 'latest') {
-                        throw new Error('Invalid revision retention policy type '+val);
+                    if (val !== 'all' && val !== 'latest' && val !== 'interval') {
+                        throw new Error('Invalid revision retention policy type ' + val);
                     }
                     break;
                 case 'grace_ttl':
@@ -120,6 +120,12 @@ function validateAndNormalizeRevPolicy(schema) {
                         throw new Error('count must be a number');
                     }
                     policy.count = val;
+                    break;
+                case 'interval':
+                    if (typeof(val) !== 'number') {
+                        throw new Error('count must be a number');
+                    }
+                    policy.interval = val;
                     break;
                 default:
                     throw new Error('Unknown revision policy attribute: ' + key);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/test/functional/multi_ranged.js
+++ b/test/functional/multi_ranged.js
@@ -207,7 +207,7 @@ describe("Multiranged tables", function() {
                 uri: "/restbase.cassandra.test.local/sys/table/multiRangeTable",
                 method: "get",
                 body: {}
-            })
+            });
         })
         .then(function(res) {
             deepEqual(res.status, 500);

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -386,7 +386,7 @@ describe('MVCC revision policy', function() {
                         comment: 'two'
                     }
                 }
-            })
+            });
         })
         .then(function(response) {
             assert.deepEqual(response.status, 201);
@@ -402,7 +402,7 @@ describe('MVCC revision policy', function() {
                         comment: 'three'
                     }
                 }
-            })
+            });
         })
             // Next day - one revision comes
         .then(function(response) {
@@ -419,7 +419,7 @@ describe('MVCC revision policy', function() {
                         comment: 'four'
                     }
                 }
-            })
+            });
         })
             // Next day tree more
         .then(function(response) {
@@ -436,7 +436,7 @@ describe('MVCC revision policy', function() {
                         comment: 'five'
                     }
                 }
-            })
+            });
         })
         .then(function(response) {
             assert.deepEqual(response.status, 201);
@@ -452,7 +452,7 @@ describe('MVCC revision policy', function() {
                         comment: 'six'
                     }
                 }
-            })
+            });
         })
         .then(function(response) {
             assert.deepEqual(response.status, 201);
@@ -468,7 +468,7 @@ describe('MVCC revision policy', function() {
                         comment: 'seven'
                     }
                 }
-            })
+            });
         })
         .delay(11000)
         .then(function(response) {
@@ -483,7 +483,7 @@ describe('MVCC revision policy', function() {
                         rev: 1000
                     }
                 }
-            })
+            });
         })
         .then(function(response) {
             assert.ok(response.body);
@@ -496,6 +496,6 @@ describe('MVCC revision policy', function() {
             assertOne(items, utils.testTidFromDate(new Date("2015-04-02 12:00:00-0500")));
             assertOne(items, utils.testTidFromDate(new Date("2015-04-03 12:30:00-0500")));
             assertOne(items, utils.testTidFromDate(new Date("2015-04-03 13:00:00-0500")));
-        })
+        });
     });
 });

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -139,6 +139,13 @@ describe('MVCC revision policy', function() {
                 method: 'delete',
                 body: {}
             });
+        })
+        .then(function() {
+            return router.request({
+                uri: '/domains_test/sys/table/' + testIntervalSchema.table,
+                method: 'delete',
+                body: {}
+            });
         });
     });
 

--- a/test/functional/secondaryIndexes.js
+++ b/test/functional/secondaryIndexes.js
@@ -391,7 +391,7 @@ describe('Indices', function() {
                 deepEqual(response.body.items[0].uri, 'uri1');
                 deepEqual(response.body.items[0].body.toString(), 'body1');
 
-            })
+            });
         });
         this.timeout(15000);
         it('successfully drop secondary index tables', function() {
@@ -406,7 +406,7 @@ describe('Indices', function() {
                     uri: "/restbase.cassandra.test.local/sys/table/simpleSecondaryIndexTable",
                     method: "get",
                     body: {}
-                })
+                });
             })
             .then(function(res) {
                 deepEqual(res.status, 500);
@@ -521,7 +521,7 @@ describe('Indices', function() {
                     uri: "/restbase.cassandra.test.local/sys/table/unversionedSecondaryIndexTable",
                     method: "get",
                     body: {}
-                })
+                });
             })
             .then(function(res) {
                 deepEqual(res.status, 500);

--- a/test/functional/simple.js
+++ b/test/functional/simple.js
@@ -62,7 +62,7 @@ describe('Simple tables', function() {
                 .then(function(response) {
                     deepEqual(response.status, 200);
                     deepEqual(response.body, simpleTableSchema);
-                })
+                });
             });
         });
         it('throws an error on unsupported schema update request', function() {
@@ -242,7 +242,7 @@ describe('Simple tables', function() {
                         },
                         if: {body: {"eq": new Buffer("<p>Service Oriented Architecture</p>")}}
                     }
-                })
+                });
             })
             .then(function(response) {
                 deepEqual(response, {status: 201});
@@ -265,7 +265,7 @@ describe('Simple tables', function() {
                     deepEqual(response.body.items[0].tid,
                         utils.testTidFromDate(new Date('2013-08-11 18:43:58-0700')));
                     deepEqual(response.body.items[0].body, new Buffer("<p>test<p>"));
-                })
+                });
             });
         });
         it ('does not inserts with if-condition in case condition is false', function() {
@@ -306,7 +306,7 @@ describe('Simple tables', function() {
                 utils.testTidFromDate(new Date('2013-08-11 18:43:58-0700')));
                 // The body was not modified
                 deepEqual(response.body.items[0].body, new Buffer("<p>test<p>"));
-            })
+            });
         });
         it('inserts static columns', function() {
             return router.request({
@@ -513,7 +513,7 @@ describe('Simple tables', function() {
                     uri: "/restbase.cassandra.test.local/sys/table/simple-table",
                     method: "get",
                     body: {}
-                })
+                });
             })
             .then(function(res) {
                 deepEqual(res.status, 500);

--- a/test/functional/types.js
+++ b/test/functional/types.js
@@ -225,7 +225,7 @@ describe('Types', function() {
                         },
                         proj: ['num_string']
                     }
-                })
+                });
             })
             .then(function(response) {
                 deepEqual(response.status, 200);
@@ -264,7 +264,7 @@ describe('Types', function() {
                     uri: "/restbase.cassandra.test.local/sys/table/typeTable",
                     method: "get",
                     body: {}
-                })
+                });
             })
             .then(function(res) {
                 deepEqual(res.status, 500);
@@ -449,7 +449,7 @@ describe('Types', function() {
                     uri: "/restbase.cassandra.test.local/sys/table/typeSetsTable",
                     method: "get",
                     body: {}
-                })
+                });
             })
             .then(function(res) {
                 deepEqual(res.status, 500);

--- a/test/functional/varint.js
+++ b/test/functional/varint.js
@@ -44,7 +44,7 @@ describe('Varint tables', function() {
         .then(function(result) {
             deepEqual(result.status, 200);
             deepEqual(result.body, varintTableSchema);
-        })
+        });
     });
     it('retrieves using varint predicates', function() {
         return router.request({
@@ -275,7 +275,7 @@ describe('Varint tables', function() {
                 uri: "/restbase.cassandra.test.local/sys/table/varintTable",
                 method: "get",
                 body: {}
-            })
+            });
         })
         .then(function(res) {
             deepEqual(res.status, 500);

--- a/test/lib/validator.js
+++ b/test/lib/validator.js
@@ -10,7 +10,7 @@ var validator = require('../../lib/validator');
 function extendSchemaInfo(schema) {
     // Create summary data on the primary data index
     schema.iKeys = schema.index.filter(function(elem) {
-        return elem.type === 'hash' || elem.type === 'range'
+        return elem.type === 'hash' || elem.type === 'range';
     })
     .map(function(elem) {
         return elem.attribute;
@@ -166,7 +166,7 @@ describe('Unit tests for validation methods', function() {
                         {attribute: 'tid', type: 'static'}
                     ]
                 });
-            }, /Cannot create static column in table without range keys/)
+            }, /Cannot create static column in table without range keys/);
         });
         it('invalid index names not allowed' , function() {
             test(function() {
@@ -266,7 +266,7 @@ describe('Unit tests for validation methods', function() {
             test(function() {
                 validator.validatePutRequest({
                     table: 'test'
-                }, null)
+                }, null);
             }, /Invalid query\. No schema/);
         });
 
@@ -287,7 +287,7 @@ describe('Unit tests for validation methods', function() {
             test(function() {
                 validator.validateGetRequest({
                     table: 'test'
-                }, null)
+                }, null);
             }, /Invalid query\. No schema/);
         });
 
@@ -296,7 +296,7 @@ describe('Unit tests for validation methods', function() {
                 validator.validateGetRequest({
                     table: 'test',
                     proj: [ 'some_random_proj_attr' ]
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Projection /);
         });
 
@@ -307,7 +307,7 @@ describe('Unit tests for validation methods', function() {
                     attributes: {
                         body: 'sample_body'
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Attribute /);
         });
 
@@ -318,7 +318,7 @@ describe('Unit tests for validation methods', function() {
                     attributes: {
                         body: undefined
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Attribute /);
         });
 
@@ -329,7 +329,7 @@ describe('Unit tests for validation methods', function() {
                     attributes: {
                         key: { gt: 'test'}
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Non\-eq conditions allowed only on range columns/);
         });
 
@@ -341,7 +341,7 @@ describe('Unit tests for validation methods', function() {
                         tid: { gt: 10},
                         range: { le: 'a'}
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Found /);
         });
 
@@ -353,7 +353,7 @@ describe('Unit tests for validation methods', function() {
                         tid: { gt: 10},
                         range: 'a'
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid query\. Found /);
         });
 
@@ -364,7 +364,7 @@ describe('Unit tests for validation methods', function() {
                     attributes: {
                         tid: { this_is_a_wrong_operator: 10}
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Illegal predicate operator/);
         });
 
@@ -375,7 +375,7 @@ describe('Unit tests for validation methods', function() {
                     order: {
                         tid: 'this-is-not-valid'
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Invalid sort order/);
         });
 
@@ -386,7 +386,7 @@ describe('Unit tests for validation methods', function() {
                     order: {
                         key: 'asc'
                     }
-                }, sampleSchema)
+                }, sampleSchema);
             }, /Cannot order on attribute/);
         });
 
@@ -396,7 +396,7 @@ describe('Unit tests for validation methods', function() {
             validator.validateGetRequest({
                 table: 'test',
                 index: 'this_does_not_exist'
-            }, sampleSchema)
+            }, sampleSchema);
         }, /Invalid query\. Index does not exist/);
     });
 });


### PR DESCRIPTION
This PR adds a tests and validation option for `interval` revision retention policy option.

An also used to implement this in both backends never removes the very first render of the revision, which is reflected in the tests.

Note that backend PRs depend on this one:
https://github.com/wikimedia/restbase-mod-table-sqlite/pull/15
https://github.com/wikimedia/restbase-mod-table-cassandra/pull/137

The bug: https://phabricator.wikimedia.org/T94524