### PR TITLE
Added test for request domain bug in sqlite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
There was a bug in SQLite module when request domain wan't honoured in get request cache, so subsequent requests to the tables in different domains under up being made for the first domain.