### PR TITLE
Tests for static column additions.

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -83,7 +83,15 @@ function validateIndexSchema(schema, index) {
         throw new Error("Indexes without hash are not yet supported!");
     }
 
-    return index;
+    var order = ['hash', 'static', 'range', 'proj'];
+    var sortedIndex = [];
+    order.forEach(function(type) {
+        sortedIndex = sortedIndex.concat(index.filter(function(idxElem) {
+            return idxElem.type === type;
+        }));
+    });
+
+    return sortedIndex;
 }
 
 /**

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -392,7 +392,7 @@ describe('MVCC revision policy', function() {
         });
     }
 
-    it('sets a TTL on all but the latest N entries (w/ 2ary index)', function() {
+/*    it('sets a TTL on all but the latest N entries (w/ 2ary index)', function() {
         return revisionRetentionTest(this, 'revPolicyLatestTest');
     });
 
@@ -484,5 +484,5 @@ describe('MVCC revision policy', function() {
             assertOne(items, utils.testTidFromDate(new Date("2015-04-02 23:00:00-0000")));
             assertOne(items, utils.testTidFromDate(new Date("2015-04-03 05:00:00-0000")));
         });
-    });
+    });*/
 });

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -392,7 +392,7 @@ describe('MVCC revision policy', function() {
         });
     }
 
-/*    it('sets a TTL on all but the latest N entries (w/ 2ary index)', function() {
+    it('sets a TTL on all but the latest N entries (w/ 2ary index)', function() {
         return revisionRetentionTest(this, 'revPolicyLatestTest');
     });
 
@@ -484,5 +484,5 @@ describe('MVCC revision policy', function() {
             assertOne(items, utils.testTidFromDate(new Date("2015-04-02 23:00:00-0000")));
             assertOne(items, utils.testTidFromDate(new Date("2015-04-03 05:00:00-0000")));
         });
-    });*/
+    });
 });

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -6,6 +6,7 @@
 var router = module.parent.router;
 var assert = require('assert');
 var extend = require('extend');
+var utils = require('../utils/test_utils.js');
 
 function clone(obj) {
     return extend(true, {}, obj);
@@ -20,7 +21,8 @@ var testTable0 = {
         rev: 'int',
         tid: 'timeuuid',
         comment: 'string',
-        author: 'string'
+        author: 'string',
+
     },
     index: [
         { attribute: 'title', type: 'hash' },
@@ -38,6 +40,8 @@ var testTable0 = {
 };
 
 describe('Schema migration', function() {
+    this.timeout(20000);
+
     before(function() {
         return router.setup()
         .then(function() {
@@ -125,13 +129,47 @@ describe('Schema migration', function() {
             assert.deepEqual(response.status, 201);
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/testTable0',
-                method: 'GET',
+                method: 'GET'
             });
         })
         .then(function(response) {
             assert.ok(response, 'undefined response');
             assert.deepEqual(response.status, 200);
             assert.deepEqual(response.body, newSchema);
+            // Verify that we can write to just added column
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0/',
+                method: 'put',
+                body: {
+                    table: 'testTable0',
+                    attributes: {
+                        title: 'add_test',
+                        rev: 1,
+                        tid: utils.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
+                        email: 'test'
+                    }
+                }
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0/',
+                method: 'get',
+                body: {
+                    table: 'testTable0',
+                    attributes: {
+                        title: 'add_test',
+                        rev: 1
+                    }
+                }
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 200);
+            assert.deepEqual(response.body.items[0].email, 'test');
         });
     });
 
@@ -176,6 +214,94 @@ describe('Schema migration', function() {
             assert.ok(
                     /is not in attributes/.test(response.body.stack),
                     'error message looks wrong');
+        });
+    });
+
+    it('handles adding static columns', function() {
+        var newSchema = clone(testTable0);
+        newSchema.version = 6;
+        newSchema.attributes.added_static_column = 'string';
+        newSchema.index = [{ attribute: 'added_static_column', type: 'static' }].concat(newSchema.index);
+        return router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+            method: 'put',
+            body: newSchema
+        })
+        .then(function(response) {
+            assert.ok(response);
+            assert.deepEqual(response.status, 201);
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+                method: 'GET'
+            });
+        })
+        .then(function(response) {
+            assert.deepEqual(response.body, newSchema);
+            // Also test that column is indeed static
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0/',
+                method: 'put',
+                body: {
+                    table: 'testTable0',
+                    attributes: {
+                        title: 'test',
+                        rev: 1,
+                        tid: utils.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
+                        added_static_column: 'test1'
+                    }
+                }
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0/',
+                method: 'put',
+                body: {
+                    table: 'testTable0',
+                    attributes: {
+                        title: 'test',
+                        rev: 2,
+                        tid: utils.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
+                        added_static_column: 'test2'
+                    }
+                }
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0/',
+                method: 'get',
+                body: {
+                    table: 'testTable0',
+                    attributes: {
+                        title: 'test',
+                        rev: 1
+                    }
+                }
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 200);
+            assert.deepEqual(response.body.items[0].added_static_column, 'test2');
+        });
+    });
+
+    it('does not change static index on existing column', function() {
+        var newSchema = clone(testTable0);
+        newSchema.version = 7;
+        newSchema.index = [{attribute: 'not_static', type: 'static'}].concat(newSchema.index);
+        return router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+            method: 'put',
+            body: newSchema
+        })
+        .then(function(response) {
+            assert.deepEqual(response.status, 500);
         });
     });
 });

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -292,6 +292,8 @@ describe('Schema migration', function() {
     it('adds one more static column', function() {
         var newSchema = clone(testTable0);
         newSchema.version = 7;
+        newSchema.attributes.added_static_column = 'string';
+        newSchema.index = [{ attribute: 'added_static_column', type: 'static' }].concat(newSchema.index);
         newSchema.attributes.added_static_column2 = 'string';
         newSchema.index = [{ attribute: 'added_static_column2', type: 'static' }].concat(newSchema.index);
         return router.request({

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -21,8 +21,7 @@ var testTable0 = {
         rev: 'int',
         tid: 'timeuuid',
         comment: 'string',
-        author: 'string',
-
+        author: 'string'
     },
     index: [
         { attribute: 'title', type: 'hash' },
@@ -40,8 +39,6 @@ var testTable0 = {
 };
 
 describe('Schema migration', function() {
-    this.timeout(20000);
-
     before(function() {
         return router.setup()
         .then(function() {

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -218,7 +218,7 @@ describe('Schema migration', function() {
         var newSchema = clone(testTable0);
         newSchema.version = 6;
         newSchema.attributes.added_static_column = 'string';
-        newSchema.index = [{ attribute: 'added_static_column', type: 'static' }].concat(newSchema.index);
+        newSchema.index.push({ attribute: 'added_static_column', type: 'static' });
         return router.request({
             uri: '/restbase.cassandra.test.local/sys/table/testTable0',
             method: 'put',
@@ -293,9 +293,9 @@ describe('Schema migration', function() {
         var newSchema = clone(testTable0);
         newSchema.version = 7;
         newSchema.attributes.added_static_column = 'string';
-        newSchema.index = [{ attribute: 'added_static_column', type: 'static' }].concat(newSchema.index);
+        newSchema.index.push({ attribute: 'added_static_column', type: 'static' });
         newSchema.attributes.added_static_column2 = 'string';
-        newSchema.index = [{ attribute: 'added_static_column2', type: 'static' }].concat(newSchema.index);
+        newSchema.index.push({ attribute: 'added_static_column2', type: 'static' });
         return router.request({
             uri: '/restbase.cassandra.test.local/sys/table/testTable0',
             method: 'put',
@@ -368,7 +368,7 @@ describe('Schema migration', function() {
     it('does not change static index on existing column', function() {
         var newSchema = clone(testTable0);
         newSchema.version = 8;
-        newSchema.index = [{attribute: 'not_static', type: 'static'}].concat(newSchema.index);
+        newSchema.index.push({attribute: 'not_static', type: 'static'});
         return router.request({
             uri: '/restbase.cassandra.test.local/sys/table/testTable0',
             method: 'put',


### PR DESCRIPTION
For page -related information we would need to be able to add static columns to the schema. This PR adds this capability to Cassandra and SQLite.