### PR TITLE
Added a check for an extra column and tests

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -330,6 +330,13 @@ validator.validatePutRequest = function(req, schema) {
         throw new Error('Invalid query. No schema for ' + req.table);
     }
 
+    var missingColumn = Object.keys(req.attributes).find(function(attrName) {
+        return !schema.attributes[attrName];
+    });
+    if (missingColumn) {
+        throw new Error('Unknown attribute ' + missingColumn);
+    }
+
     schema.iKeys.forEach(function(key) {
         if (req.attributes[key] === undefined && key !== schema.tid) {
             throw new Error("Index attribute " + JSON.stringify(key) + " missing in "

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/test/functional/invalid_requests.js
+++ b/test/functional/invalid_requests.js
@@ -155,4 +155,40 @@ describe('Invalid request handling', function() {
             deepEqual(response.status, 500);
         });
     });
+
+    it('fails to insert unknown field', function() {
+        return router.request({
+            method: 'put',
+            uri: '/restbase.cassandra.test.local/sys/table/extraFieldSchema',
+            body: {
+                domain: 'restbase.cassandra.test.local',
+                table: 'extraFieldSchema',
+                attributes: {
+                    key: 'string',
+                    value: 'string'
+                },
+                index: [
+                    { attribute: 'key', type: 'hash' }
+                ]
+            }
+        })
+        .then(function(res) {
+            deepEqual(res.status, 201);
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/extraFieldSchema/',
+                method: 'put',
+                body: {
+                    table: 'extraFieldSchema',
+                    attributes: {
+                        key: 'key',
+                        value: 'value',
+                        extra_field: 'extra_value'
+                    }
+                }
+            });
+        })
+        .then(function(res) {
+            deepEqual(res.status, 500);
+        });
+    });
 });

--- a/test/lib/validator.js
+++ b/test/lib/validator.js
@@ -280,6 +280,21 @@ describe('Unit tests for validation methods', function() {
                 }, sampleSchema);
             }, /Index attribute/);
         });
+
+        it('all attributes must exist in schema', function() {
+            test(function() {
+                validator.validatePutRequest({
+                    table: 'test',
+                    attributes: {
+                        key: 'key',
+                        tid: 'timeuuid',
+                        latestTid: 'timeuuid',
+                        range: 'string',
+                        extra_column: 'extra'
+                    }
+                }, sampleSchema);
+            }, /Unknown attribute extra_column/);
+        });
     });
 
     describe('GET request validation', function() {


### PR DESCRIPTION
When we try to insert a field that's not in the schema, cassandra silently ignores that and SQLite is throwing a non-descriptive error. However, extra fields clearly indicate a bug in the client - either on table schema, or on a query, so we need to fail-fast and throw an error.

After this is merged, SQLite module would be updated to require the news version of spec and anew version of sqlite will be released.