### PR TITLE
Added a test that checks a revisionretentionPolicy with 0 revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -438,7 +438,7 @@ describe('MVCC revision policy', function() {
             assert.deepEqual(res.status, 404);
             assert.ok(res.body);
             assert.deepEqual(res.body.items.length, 0);
-        })
+        });
     });
 
     // Checks interval rev retention policy: need to ensure we have max 2 renders every 24 hours

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -398,7 +398,7 @@ describe('MVCC revision policy', function() {
         return revisionRetentionTest(this, 'revPolicyLatestTest-no2ary');
     });
 
-    it('supports count=0 in latests policy', function() {
+    it('supports count=0 in latest policy', function() {
         this.timeout(10000);
 
         return P.each([1,2,3], function(index) {


### PR DESCRIPTION
In cassandra we start looking at a revisionRetentionPolicy starting from a row just after the row we've just inserted. This needs to be updated to support policy with count === 0, that just set a graceTTL.

SQLite module doesn't need updates, cassandra module is updated at https://github.com/wikimedia/restbase-mod-table-cassandra/pull/156