### PR TITLE
Rewrite ttl revision policy to latest with count = 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ When `revisionRetentionPolicy.type` is `interval`, each `revisionRetentionPolicy
 items are maintained each `revisionRetentionPolicy.interval` milliseconds.
 Removed items expire no less than `revisionRetentionPolicy.grace_ttl` seconds.
 
-### temp
-When `revisionRetentionPolicy.type` is `temp`, all items are maintained only for
-`revisionRetentionPolicy.grace_ttl` seconds, and expire after that period.
+### ttl
+When `revisionRetentionPolicy.type` is `ttl`, all items are maintained no less than for
+`revisionRetentionPolicy.ttl` seconds, and expire after that period.
 
 # Queries
 Select the first 50 entries:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ When `revisionRetentionPolicy.type` is `latest`, the last
 `revisionRetentionPolicy.count` records are maintained, any others are
 expired in no less than `revisionRetentionPolicy.grace_ttl` seconds.
 
+### interval
+When `revisionRetentionPolicy.type` is `interval`, each `revisionRetentionPolicy.count`
+items are maintained each `revisionRetentionPolicy.interval` milliseconds.
+Removed items expire no less than `revisionRetentionPolicy.grace_ttl` seconds.
+
+### temp
+When `revisionRetentionPolicy.type` is `temp`, all items are maintained only for
+`revisionRetentionPolicy.grace_ttl` seconds, and expire after that period.
+
 # Queries
 Select the first 50 entries:
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -109,7 +109,7 @@ function validateAndNormalizeRevPolicy(schema) {
 
     if (schema.revisionRetentionPolicy) {
         policy = schema.revisionRetentionPolicy;
-        // Rewrite the `temp` policy to latest with count = 0
+        // Rewrite the `ttl` policy to latest with count = 0
         if (policy.type === 'ttl') {
             policy.type = 'latest';
             policy.count = 0;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -110,9 +110,14 @@ function validateAndNormalizeRevPolicy(schema) {
     if (schema.revisionRetentionPolicy) {
         policy = schema.revisionRetentionPolicy;
         // Rewrite the `temp` policy to latest with count = 0
-        if (policy.type === 'temp') {
+        if (policy.type === 'ttl') {
             policy.type = 'latest';
             policy.count = 0;
+            if (typeof(policy.ttl) !== 'number') {
+                throw new Error('ttl must be a number');
+            }
+            policy.grace_ttl = policy.ttl;
+            delete policy.ttl;
         }
 
         Object.keys(policy).forEach(function(key) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -109,6 +109,12 @@ function validateAndNormalizeRevPolicy(schema) {
 
     if (schema.revisionRetentionPolicy) {
         policy = schema.revisionRetentionPolicy;
+        // Rewrite the `temp` policy to latest with count = 0
+        if (policy.type === 'temp') {
+            policy.type = 'latest';
+            policy.count = 0;
+        }
+
         Object.keys(policy).forEach(function(key) {
             var val = policy[key];
             switch(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -49,8 +49,8 @@ var testSchema = {
     }
 };
 
-var testSchemaZeroRevisions = {
-    table: 'testSchemaZeroRevisions',
+var testSchemaTempPolicy = {
+    table: 'testSchemaTempPolicy',
     options: { durability: 'low' },
     attributes: {
         title: 'string',
@@ -65,8 +65,7 @@ var testSchemaZeroRevisions = {
         { attribute: 'tid', type: 'range', order: 'desc' }
     ],
     revisionRetentionPolicy: {
-        type: 'latest',
-        count: 0,
+        type: 'temp',
         grace_ttl: 3
     }
 };
@@ -143,7 +142,7 @@ describe('MVCC revision policy', function() {
                 testSchemaNo2ary,
                 testIntervalSchema,
                 testIntervalSchema2,
-                testSchemaZeroRevisions]
+                testSchemaTempPolicy]
             .map(function(schema) {
                 return router.request({
                     uri: '/domains_test/sys/table/' + schema.table,
@@ -162,7 +161,7 @@ describe('MVCC revision policy', function() {
             testSchemaNo2ary,
             testIntervalSchema,
             testIntervalSchema2,
-            testSchemaZeroRevisions]
+            testSchemaTempPolicy]
         .map(function(schema) {
             return router.request({
                 uri: '/domains_test/sys/table/' + schema.table,
@@ -398,15 +397,15 @@ describe('MVCC revision policy', function() {
         return revisionRetentionTest(this, 'revPolicyLatestTest-no2ary');
     });
 
-    it('supports count=0 in latest policy', function() {
+    it('supports temp revision policy', function() {
         this.timeout(10000);
 
         return P.each([1,2,3], function(index) {
             return router.request({
-                uri: '/domains_test/sys/table/'+ testSchemaZeroRevisions.table +'/',
+                uri: '/domains_test/sys/table/'+ testSchemaTempPolicy.table +'/',
                 method: 'put',
                 body: {
-                    table: testSchemaZeroRevisions.table,
+                    table: testSchemaTempPolicy.table,
                     attributes: {
                         title: 'revisioned',
                         rev: 1000,
@@ -423,10 +422,10 @@ describe('MVCC revision policy', function() {
         .delay(5000)
         .then(function() {
             return router.request({
-                uri: '/domains_test/sys/table/'+ testSchemaZeroRevisions.table +'/',
+                uri: '/domains_test/sys/table/'+ testSchemaTempPolicy.table +'/',
                 method: 'get',
                 body: {
-                    table: testSchemaZeroRevisions.table,
+                    table: testSchemaTempPolicy.table,
                     attributes: {
                         title: 'Revisioned',
                         rev: 1000

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -49,8 +49,8 @@ var testSchema = {
     }
 };
 
-var testSchemaTempPolicy = {
-    table: 'testSchemaTempPolicy',
+var testSchemaTtlPolicy = {
+    table: 'testSchemaTtlPolicy',
     options: { durability: 'low' },
     attributes: {
         title: 'string',
@@ -65,8 +65,8 @@ var testSchemaTempPolicy = {
         { attribute: 'tid', type: 'range', order: 'desc' }
     ],
     revisionRetentionPolicy: {
-        type: 'temp',
-        grace_ttl: 3
+        type: 'ttl',
+        ttl: 3
     }
 };
 
@@ -142,7 +142,7 @@ describe('MVCC revision policy', function() {
                 testSchemaNo2ary,
                 testIntervalSchema,
                 testIntervalSchema2,
-                testSchemaTempPolicy]
+                testSchemaTtlPolicy]
             .map(function(schema) {
                 return router.request({
                     uri: '/domains_test/sys/table/' + schema.table,
@@ -161,7 +161,7 @@ describe('MVCC revision policy', function() {
             testSchemaNo2ary,
             testIntervalSchema,
             testIntervalSchema2,
-            testSchemaTempPolicy]
+            testSchemaTtlPolicy]
         .map(function(schema) {
             return router.request({
                 uri: '/domains_test/sys/table/' + schema.table,
@@ -402,10 +402,10 @@ describe('MVCC revision policy', function() {
 
         return P.each([1,2,3], function(index) {
             return router.request({
-                uri: '/domains_test/sys/table/'+ testSchemaTempPolicy.table +'/',
+                uri: '/domains_test/sys/table/'+ testSchemaTtlPolicy.table +'/',
                 method: 'put',
                 body: {
-                    table: testSchemaTempPolicy.table,
+                    table: testSchemaTtlPolicy.table,
                     attributes: {
                         title: 'revisioned',
                         rev: 1000,
@@ -422,10 +422,10 @@ describe('MVCC revision policy', function() {
         .delay(5000)
         .then(function() {
             return router.request({
-                uri: '/domains_test/sys/table/'+ testSchemaTempPolicy.table +'/',
+                uri: '/domains_test/sys/table/'+ testSchemaTtlPolicy.table +'/',
                 method: 'get',
                 body: {
-                    table: testSchemaTempPolicy.table,
+                    table: testSchemaTtlPolicy.table,
                     attributes: {
                         title: 'Revisioned',
                         rev: 1000


### PR DESCRIPTION
After we've added support for `latest` revision policy with `count === 0`, a better name is needed for it. Here we use `temp`, but I'm happy to do some bike shedding on the naming. @wikimedia/services what are your thoughts?