### PR TITLE
Better cleanup test tables after tests

### DIFF
--- a/test/functional/invalid_requests.js
+++ b/test/functional/invalid_requests.js
@@ -6,9 +6,19 @@
 var router = module.parent.router;
 var utils = require('../utils/test_utils.js');
 var deepEqual = utils.deepEqual;
+var P = require('bluebird');
 
 describe('Invalid request handling', function() {
     before(function () { return router.setup(); });
+
+    after(function() {
+        return P.all(['extraFieldSchema', 'orderTest'].map(function(schemaName) {
+            return router.request({
+                method: 'delete',
+                uri: '/restbase.cassandra.test.local/sys/table/' + schemaName
+            });
+        }));
+    });
 
     it('fails when writing to non-existent table', function() {
         return router.request({

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -57,8 +57,7 @@ describe('Schema migration', function() {
     after(function() {
         return router.request({
             uri: '/restbase.cassandra.test.local/sys/table/testTable0',
-            method: 'DELETE',
-            body: {}
+            method: 'delete'
         });
     });
 

--- a/test/functional/secondaryIndexes.js
+++ b/test/functional/secondaryIndexes.js
@@ -81,6 +81,13 @@ describe('Indices', function() {
         }
     };
 
+    after(function() {
+        router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/secondaryIndexSchemaWithRangeKeys',
+            method: 'delete'
+        });
+    });
+
     context('Secondary indices', function() {
         it('creates a secondary index table', function() {
             this.timeout(15000);

--- a/test/functional/simple.js
+++ b/test/functional/simple.js
@@ -44,6 +44,13 @@ describe('Simple tables', function() {
         ]
     };
 
+    after(function() {
+        return router.request({
+            uri: '/restbase1.cassandra.test.local/sys/table/simple-table',
+            method: 'delete'
+        });
+    });
+
     context('Create', function() {
         before(function() {
             // Create a same table on different domain


### PR DESCRIPTION
In cassandra module, we don't run any table-cleanup-script after running tests, but rely on tests to delete the tables before the next run. Some tables were not deleted, which sometimes cause problems with test modification/rerun. 