### PR TITLE
Release 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The module has matured enough to be considered for v0.1.0. Besides,
0.0.x has a special meaning in semver, so ^0.0.x doesn't work as well
when bumping versions.