### PR TITLE
Spec & tests: Support custom _ttl attributes for individual rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Removed items expire no less than `revisionRetentionPolicy.grace_ttl` seconds.
 When `revisionRetentionPolicy.type` is `ttl`, all items are maintained no less than for
 `revisionRetentionPolicy.ttl` seconds, and expire after that period.
 
+## Custom TTL
+A custom TTL can be set for individual objects on `PUT` requests by providing a special
+`_ttl` integer attribute. Its value indicates the amount of time (in seconds) after which
+the record will be removed from storage.
+
+Please note, that setting custom `_ttl` for individual rows is not allowed for tables which
+have a revision retention policy set, as table-wide and row-wide TTLs would conflict.
+
 # Queries
 Select the first 50 entries:
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -345,8 +345,18 @@ validator.validatePutRequest = function(req, schema) {
     var missingColumn = Object.keys(req.attributes).find(function(attrName) {
         return !schema.attributes[attrName];
     });
+    // _ttl is a special attribute, that might not be present in the schema,
+    // but still allowed on the put request to set row TTL
     if (missingColumn) {
-        throw new Error('Unknown attribute ' + missingColumn);
+        if (missingColumn === '_ttl') {
+            if(schema.revisionRetentionPolicy
+                    && schema.revisionRetentionPolicy.type !== 'all') {
+                throw new Error('Invalid request: ' +
+                  'custom _ttl is not allowed on tables with a revision retention policy');
+            }
+        } else {
+            throw new Error('Unknown attribute ' + missingColumn);
+        }
     }
 
     schema.iKeys.forEach(function(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR adds support for setting a `_ttl` attribute on `PUT` queries, which represents a row TTL in seconds. Mixing `revisionRetentionPolicy` other than `all` with custom TTLs is not allowed, because it will break the policy contract.

The primary goal of this feature, it to make proper support for `preview` mode in public graphoid endpoints in RETBase (https://github.com/wikimedia/restbase/pull/388).

Corresponding backends changes:
SQLite: https://github.com/wikimedia/restbase-mod-table-sqlite/pull/27
Cassandra: https://github.com/wikimedia/restbase-mod-table-cassandra/pull/164

cc @wikimedia/services 