### PR TITLE
Spec & Tests: Support long type in storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Example:
   implementation decodes JSON to doubles, this is also the maximum range the
   we currently support in practice. We might add support for an alternative
   JSON string representation of larger integers in the future.
+- `long`: A 64-bit signed long. Javascript only represents 52 bits in its `Number`
+   type, so longs should be represented as strings in clients.
 - `decimal`: Decimal number.
 - `float`: Single-precision (32-bit) floating point number.
 - `double`: Double-precision (64-bit) floating point number.

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -13,7 +13,8 @@ var validTypes = ['blob', 'set<blob>',
     'timeuuid', 'set<timeuuid>',
     'uuid', 'set<uuid>',
     'timestamp', 'set<timestamp>',
-    'json', 'set<json>'
+    'json', 'set<json>',
+    'long', 'set<long>'
 ];
 
 var validPredKeys = ['eq', 'lt', 'gt', 'le', 'ge', 'between'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Adds spec changes and tests required to support `long` type in backends:
Corresponding PRs for backends:
Cassandra: https://github.com/wikimedia/restbase-mod-table-cassandra/pull/163
SQLite: https://github.com/wikimedia/restbase-mod-table-sqlite/pull/26

Bug: https://phabricator.wikimedia.org/T85576