### PR TITLE
Tests: Make static column tests pass on travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -53,15 +53,7 @@ var testTableNoRevPolicy = {
         { attribute: 'title', type: 'hash' },
         { attribute: 'rev', type: 'range', order: 'desc' },
         { attribute: 'tid', type: 'range', order: 'desc' }
-    ],
-    secondaryIndexes: {
-        by_rev : [
-            { attribute: 'rev', type: 'hash' },
-            { attribute: 'tid', type: 'range', order: 'desc' },
-            { attribute: 'title', type: 'range', order: 'asc' },
-            { attribute: 'comment', type: 'proj' }
-        ]
-    }
+    ]
 };
 
 describe('Schema migration', function() {
@@ -258,9 +250,9 @@ describe('Schema migration', function() {
        on tables where the static column was added, which affects our revision
        retention policy code. This test will fail on cassandra < 2.2.*, so for now
        it's commented out. When we start requiring newer cassandra version, this
-       should be uncommented.
+       should be uncommented. */
 
-    it('adds static columns with rev policy', function() {
+    it.skip('adds static columns with rev policy', function() {
         var newSchema = clone(testTable0);
         newSchema.version = 6;
         newSchema.attributes.added_static_column = 'string';
@@ -333,7 +325,6 @@ describe('Schema migration', function() {
             assert.deepEqual(response.body.items[0].added_static_column, 'test2');
         });
     });
-    */
 
     /* This test duplicates the previous commented-out one with a difference
        that it's run on a table without a revision retention policy.


### PR DESCRIPTION
https://github.com/wikimedia/restbase-mod-table-spec/pull/29 modified one of the schema migration tests, but it was not enough. Follow up is here.