### PR TITLE
Tests for latest_hash rev policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Removed items expire no less than `revisionRetentionPolicy.grace_ttl` seconds.
 When `revisionRetentionPolicy.type` is `ttl`, all items are maintained no less than for
 `revisionRetentionPolicy.ttl` seconds, and expire after that period.
 
+### latest_hash
+When `revisionRetentionPolicy.type` is `latest_hash`, only the latest row per `hash` key
+is kept, all the previous are deleted. The order is established by the ordering of the
+first `range` key. This retention policy is not supported for tables with secondary indexes
+and for tables with no `range` keys other than `tid`.
+
 ## Custom TTL
 A custom TTL can be set for individual objects on `PUT` requests by providing a special
 `_ttl` integer attribute. Its value indicates the amount of time (in seconds) after which

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -120,12 +120,23 @@ function validateAndNormalizeRevPolicy(schema) {
             policy.grace_ttl = policy.ttl;
             delete policy.ttl;
         }
+        // Check that latest_hash has no secondary indexes
+        if (policy.type === 'latest_hash') {
+            if (schema.secondaryIndexes && Object.keys(schema.secondaryIndexes).length) {
+                throw new Error('Revision policy "latest_hash" is not supported with secondary indexes');
+            }
+            policy.grace_ttl = 1;
+            policy.count = 1;
+        }
 
         Object.keys(policy).forEach(function(key) {
             var val = policy[key];
             switch(key) {
                 case 'type':
-                    if (val !== 'all' && val !== 'latest' && val !== 'interval') {
+                    if (val !== 'all'
+                            && val !== 'latest'
+                            && val !== 'interval'
+                            && val !== 'latest_hash') {
                         throw new Error('Invalid revision retention policy type ' + val);
                     }
                     break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {
@@ -37,12 +37,12 @@
     "js-yaml": "^3.5.2"
   },
   "devDependencies": {
-    "bluebird": "~3.1.1",
-    "coveralls": "2.11.6",
+    "bluebird": "~3.3.3",
+    "coveralls": "2.11.8",
     "extend": "^3.0.0",
     "istanbul": "0.4.2",
-    "mocha-lcov-reporter": "1.0.0",
-    "mocha": "2.3.4",
-    "mocha-jshint": "2.2.6"
+    "mocha-lcov-reporter": "1.2.0",
+    "mocha": "2.4.5",
+    "mocha-jshint": "2.3.1"
   }
 }


### PR DESCRIPTION
Tests and validation improvements for `latest_hash` policy. The idea is to implement a revision policy that would only keep the latest revision in the `key_rev_value` bucket. The policy implementation is quite generic - we will just remove all the older content where 'older' is defined by the order of the first `range` key in the table schema. 

Bug: https://phabricator.wikimedia.org/T128419

cc @wikimedia/services 