### PR TITLE
Re-order overlapping table spec definitions; v0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {

--- a/table.yaml
+++ b/table.yaml
@@ -17,13 +17,12 @@ paths:
     get:
       operationId: getTableSchema
 
-  /{table}/{+rest}:
-    get: *get
-    put: *put
-    post: *put
-
   /{table}/:
     get: *get
     put: *put
     post: *put
 
+  /{table}/{+rest}:
+    get: *get
+    put: *put
+    post: *put


### PR DESCRIPTION
https://github.com/wikimedia/swagger-router/pull/51 changed the handling
of overlapping routes ending in a slash. As a result, we now need to
list the higher level route first, to avoid conflicts during tree
construction.