### PR TITLE
Make fetching the test utils on demand

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
             require('./test/functional/' + file);
         });
     },
-    testUtils: require('./test/utils/test_utils.js'),
+    getTestUtils: () => require('./test/utils/test_utils.js'),
     spec: yaml.safeLoad(fs.readFileSync(__dirname + '/table.yaml')),
     validator: require('./lib/validator')
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase-mod-table-spec",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Tests and specification for RESTBase backend modules",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This will break storage modules tests, but they are broken anyway right now because of npm not fetching the test directories for dependencies.

cc @wikimedia/services 